### PR TITLE
Build from source instead of installing pre-built binaries

### DIFF
--- a/Formula/vmnet-helper.rb
+++ b/Formula/vmnet-helper.rb
@@ -4,8 +4,8 @@
 class VmnetHelper < Formula
   desc "High-performance network proxy connecting VMs to macOS vmnet"
   homepage "https://github.com/nirs/vmnet-helper"
-  url "https://github.com/nirs/vmnet-helper/archive/refs/tags/v0.12.0-pre4.tar.gz"
-  sha256 "be68b95fae43f556d6c8fe8345a4bb78def1792d7f9e835534eb55d3c27ef0d7"
+  url "https://github.com/nirs/vmnet-helper/archive/refs/tags/v0.12.0.tar.gz"
+  sha256 "fa95f12173e061ff6bafac9cce3cf5d5efeb8457cf1f756403c165d444ab9d53"
   license "Apache-2.0"
   head "https://github.com/nirs/vmnet-helper.git", branch: "main"
 

--- a/Formula/vmnet-helper.rb
+++ b/Formula/vmnet-helper.rb
@@ -4,21 +4,28 @@
 class VmnetHelper < Formula
   desc "High-performance network proxy connecting VMs to macOS vmnet"
   homepage "https://github.com/nirs/vmnet-helper"
-  url "https://github.com/nirs/vmnet-helper/releases/download/v0.11.0/vmnet-helper.tar.gz"
-  sha256 "dfeca3e8cc9d9b1e0e40df12e42975f10433b9ccbb8f0a239d42df99611caa76"
+  url "https://github.com/nirs/vmnet-helper/archive/refs/tags/v0.12.0-pre4.tar.gz"
+  sha256 "be68b95fae43f556d6c8fe8345a4bb78def1792d7f9e835534eb55d3c27ef0d7"
   license "Apache-2.0"
+  head "https://github.com/nirs/vmnet-helper.git", branch: "main"
 
-  depends_on :macos => :tahoe
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on macos: :tahoe
 
   def install
-    libexec.install "vmnet-helper/bin/vmnet-helper"
-    libexec.install "vmnet-helper/bin/vmnet-run"
-    rm_f libexec/"vmnet-client"
+    system "meson", "setup", "build", *std_meson_args, "--bindir=#{libexec}"
+    system "meson", "compile", "-C", "build"
+    system "meson", "install", "-C", "build"
+    system "codesign", "--force", "--sign", "-",
+           "--entitlements", "building/entitlements.plist",
+           libexec/"vmnet-helper"
   end
 
   test do
     output = shell_output("#{libexec}/vmnet-helper --version")
-    assert_match "v0.11.0", output
-    assert_match "3164bb571e132022a9c35621b3e3bb1db5fb8a3b", output
+    assert_match "v#{version}", output
+    output = shell_output("codesign -d --entitlements - #{libexec}/vmnet-helper")
+    assert_match "com.apple.security.virtualization", output
   end
 end

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Development targets for testing the formula. See README.md for usage.
+
+TAP = nirs/vmnet-helper
+TAP_DIR = $(shell brew --repo $(TAP) 2>/dev/null)
+BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+.PHONY: tap untap sync install uninstall test audit
+
+tap:
+	brew tap $(TAP) $(CURDIR)
+
+untap:
+	-brew uninstall vmnet-helper
+	-brew untap $(TAP)
+
+sync:
+	cd $(TAP_DIR) && git fetch origin && git checkout $(BRANCH) && git reset --hard origin/$(BRANCH)
+
+install: sync
+	brew install --verbose vmnet-helper
+
+uninstall:
+	brew uninstall --verbose vmnet-helper
+
+test: sync
+	brew test --verbose vmnet-helper
+
+audit: sync
+	brew audit --strict vmnet-helper

--- a/README.md
+++ b/README.md
@@ -14,6 +14,46 @@ brew install vmnet-helper
 > For macOS 15 and earlier see
 > [installation](https://github.com/nirs/vmnet-helper#installation).
 
-## More Information
+## Documentation
 
 See [vmnet-helper](https://github.com/nirs/vmnet-helper) for documentation.
+
+## Development
+
+### Setup
+
+Remove the current tap if installed, then tap from your local clone:
+
+```console
+make untap
+make tap
+```
+
+### Install and test
+
+```console
+make install
+make test
+make audit
+```
+
+### After switching branches or making new commits
+
+```console
+make sync
+```
+
+### Bump to a new release
+
+After tagging a new release in the
+[vmnet-helper](https://github.com/nirs/vmnet-helper) repo:
+
+```console
+./bump.sh v0.12.0
+make install
+make test
+make audit
+```
+
+The bump script downloads the source tarball, computes the SHA256, and
+updates the formula URL and hash.

--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: The vmnet-helper authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Update the formula to a new release version.
+
+set -eo pipefail
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 VERSION"
+    echo "Example: $0 v0.12.0-pre4"
+    exit 1
+fi
+
+version=$1
+formula=Formula/vmnet-helper.rb
+url="https://github.com/nirs/vmnet-helper/archive/refs/tags/${version}.tar.gz"
+
+echo "Downloading ${url} ..."
+sha=$(curl -fsSL "$url" | shasum -a 256 | cut -d' ' -f1)
+
+sed -i '' "s|archive/refs/tags/.*\.tar\.gz|archive/refs/tags/${version}.tar.gz|" "$formula"
+sed -i '' "s|sha256 \".*\"|sha256 \"${sha}\"|" "$formula"
+
+echo "Updated ${formula} to ${version} (${sha})"


### PR DESCRIPTION
Build vmnet-helper from source instead of installing pre-built binaries.
This is a prerequisite for submitting the formula to homebrew-core.

- Build from GitHub source archive using meson + ninja
- Ad-hoc sign the binary with the vmnet entitlement after build
- Add `head` block for building from main
- Test version string and codesign entitlement
- Add development tooling (Makefile, bump.sh, README)

## What changes for users

- The C code is compiled locally instead of downloading pre-built binaries
- This is seamless: Homebrew provides the compiler via Xcode Command Line
  Tools, and meson/ninja are installed automatically as build dependencies
- Install path (`libexec`) is unchanged -- minikube compatibility preserved

## Tested

- [x] `brew install --verbose vmnet-helper` (stable, from tarball)
- [x] `brew install --verbose --HEAD vmnet-helper` (from git)
- [x] `brew test --verbose vmnet-helper`
- [x] `brew audit --strict vmnet-helper`
- [x] `vmnet-run -- sleep 1` (vmnet interface creation)

## Issues

- [x] Update to vmnet-helper v0.12.0

---
Fixes #2 